### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,16 +1,17 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  dependabot:
-    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@8f72b028f3bbb741244c9fde8633ecb5ceb77fd0 # v4.9.38
+  approve:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -5,11 +5,12 @@ name: 'Dependabot auto approval'
 
 on:
   pull_request_target
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+  dependabot:
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@8f72b028f3bbb741244c9fde8633ecb5ceb77fd0 # v4.9.38
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@cbd9f111b346d01bd898e5be090858473149119b # v4.9.37
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@cbd9f111b346d01bd898e5be090858473149119b # v4.9.37
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,31 +18,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
-  basicListener:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+  ci:
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7
     with:
-      lint-skip:            true
-      release-skip-publish: --skip-publish
-      release-type:         program
-      release-main-package: basicListener
-      working-directory:    basicListener
-    secrets: inherit
-  configurableListener:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
-    with:
-      lint-skip:            true
-      release-skip-publish: --skip-publish
-      release-type:         program
-      release-main-package: configurableListener
-      working-directory:    configurableListener
-    secrets: inherit
-  timedListener:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
-    with:
-      lint-skip:            true
-      release-skip-publish: --skip-publish
-      release-type:         program
-      release-main-package: timedListener
-      working-directory:    timedListener
+      release-type: library
+      yaml-lint-skip: false
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,30 @@ permissions:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
-      release-type: library
-      yaml-lint-skip: false
+      lint-skip:            true
+      release-skip-publish: --skip-publish
+      release-type:         program
+      release-main-package: basicListener
+      working-directory:    basicListener
+    secrets: inherit
+  configurableListener:
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+    with:
+      lint-skip:            true
+      release-skip-publish: --skip-publish
+      release-type:         program
+      release-main-package: configurableListener
+      working-directory:    configurableListener
+    secrets: inherit
+  timedListener:
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28
+    with:
+      lint-skip:            true
+      release-skip-publish: --skip-publish
+      release-type:         program
+      release-main-package: timedListener
+      working-directory:    timedListener
     secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+  project:
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@8f72b028f3bbb741244c9fde8633ecb5ceb77fd0 # v4.9.38
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
@@ -17,6 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  project:
-    uses: xmidt-org/shared-go/.github/workflows/proj.yml@8f72b028f3bbb741244c9fde8633ecb5ceb77fd0 # v4.9.38
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

Normalizes CI/CD workflows to match xmidt-org Ideal State standards.

## Changes

- **ci.yml**: Changed job name from `basicListener`/`configurableListener`/`timedListener` to `ci`, set `release-type` to `library`, changed `lint-skip: true` to `yaml-lint-skip: false`, added top-level `permissions` block, updated to v4.8.7
- **approve-dependabot.yml**: Renamed from `dependabot-approver.yml`, updated to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@v4.9.38` with proper SHA pinning
- **proj-xmidt-team.yml**: Updated to reference `xmidt-org/shared-go/.github/workflows/proj.yml@v4.9.38` with proper SHA pinning, added `permissions` block
- **auto-releaser.yml**: Created new file to reference `xmidt-org/shared-go/.github/workflows/auto-releaser.yml@v4.9.37`

All workflow references now use full commit SHA pinning with version comments.

Closes #37